### PR TITLE
Load DOM in PageQualityScorer and allow ignoring elements on page by class

### DIFF
--- a/PageQualityScorer.php
+++ b/PageQualityScorer.php
@@ -82,9 +82,10 @@ abstract class PageQualityScorer{
 		// Unicode-compatibility - see https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly
 		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
 		$dom->preserveWhiteSpace = false;
+		self::$dom = $dom;
 		self::removeIgnoredElements();
 
-		return self::$dom = $dom;
+		return self::$dom;
 	}
 
 	/**
@@ -126,7 +127,7 @@ abstract class PageQualityScorer{
 	}
 
 	protected static function removeIgnoredElements () {
-		$ignoredElements = self::getElementsByClassName( self::$dom, 'pagequality-ignore' );
+		$ignoredElements = self::getElementsByClassName( self::getDOM(), 'pagequality-ignore' );
 		foreach ( $ignoredElements as $element ) {
 			$element->parentNode->removeChild( $element );
 		}

--- a/PageQualityScorer.php
+++ b/PageQualityScorer.php
@@ -35,7 +35,7 @@ abstract class PageQualityScorer{
 
 	public static function loadAllScoreres() {
 		foreach ( glob( __DIR__ . "/scorers/*.php") as $filename ) {
-		    include_once $filename;
+			include_once $filename;
 			self::$registered_classes[] = basename($filename, '.php');
 		}
 	}
@@ -81,6 +81,8 @@ abstract class PageQualityScorer{
 		$dom = new DOMDocument('1.0', 'utf-8');
 		// Unicode-compatibility - see https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly
 		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
+		$dom->preserveWhiteSpace = false;
+		self::removeIgnoredElements();
 
 		return self::$dom = $dom;
 	}
@@ -116,4 +118,18 @@ abstract class PageQualityScorer{
 		}
 		return [ $score, $responses ];
 	}
+
+	protected static function getElementsByClassName( DOMDocument $dom, $className ) {
+		$xpath = new DOMXpath( $dom );
+		$expression = '//*[contains(concat(" ", normalize-space(@class), " "), " ' . $className . ' ")]';
+		return $xpath->query( $expression );
+	}
+
+	protected static function removeIgnoredElements () {
+		$ignoredElements = self::getElementsByClassName( self::$dom, 'pagequality-ignore' );
+		foreach ( $ignoredElements as $element ) {
+			$element->parentNode->removeChild( $element );
+		}
+	}
+
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # PageQuality
 A MediaWiki extension to monitor and improve Page Quality
+
+# Excluding elements on the page
+Elements with the CSS class `.pagequality-ignore` will be excluded from the audits. 

--- a/scorers/PageQualityScorerCalloutsRules.php
+++ b/scorers/PageQualityScorerCalloutsRules.php
@@ -23,17 +23,11 @@ class PageQualityScorerCalloutsRules extends PageQualityScorer{
 		],
 	];
 
-
-	public function calculatePageScore( $text ) {
+	public function calculatePageScore() {
 		$response = [];
 
-		// @todo load only actual page content. right now this will also load stuff like the "protectedpagewarning" message
-		$dom = new DOMDocument('1.0', 'utf-8');
-		// Unicode-compatibility - see https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly
-		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
-
 		$count = 0;
-		$divNodes = $dom->getElementsByTagName('div');
+		$divNodes = self::getDOM()->getElementsByTagName('div');
 	    for ($i = 0; $i < $divNodes->length; $i++) {
 	        if (stripos($divNodes->item($i)->getAttribute('class'), "wr-example") !== false) {
 	        	$count++;

--- a/scorers/PageQualityScorerEmphasisRules.php
+++ b/scorers/PageQualityScorerEmphasisRules.php
@@ -40,16 +40,11 @@ class PageQualityScorerEmphasisRules extends PageQualityScorer{
 	];
 
 
-	public function calculatePageScore( $text ) {
+	public function calculatePageScore() {
 		$response = [];
-
-		// @todo load only actual page content. right now this will also load stuff like the "protectedpagewarning" message
-		$dom = new DOMDocument('1.0', 'utf-8');
-		// Unicode-compatibility - see https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly
-		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
 		$count = 0;
 		$emphasis_gov = false;
-		$divNodes = $dom->getElementsByTagName('div');
+		$divNodes = self::getDOM()->getElementsByTagName('div');
 	    for ($i = 0; $i < $divNodes->length; $i++) {
 	        if ( stripos($divNodes->item($i)->getAttribute('class'), "emphasis-item") !== false
 	        	&&

--- a/scorers/PageQualityScorerReadability.php
+++ b/scorers/PageQualityScorerReadability.php
@@ -34,15 +34,10 @@ class PageQualityScorerReadability extends PageQualityScorer{
 	];
 
 
-	public function calculatePageScore( $text ) {
+	public function calculatePageScore() {
 		$response = [];
 
-		// @todo load only actual page content. right now this will also load stuff like the "protectedpagewarning" message
-		$dom = new DOMDocument('1.0', 'utf-8');
-		// Unicode-compatibility - see https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly
-		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
-		$pNodes = $dom->getElementsByTagName('p');
-
+		$pNodes = self::getDOM()->getElementsByTagName('p');
 		foreach ( $pNodes as $pNode ) {
 			$wc = self::str_word_count_utf8( $pNode->nodeValue );
 

--- a/scorers/PageQualityScorerTableRules.php
+++ b/scorers/PageQualityScorerTableRules.php
@@ -20,15 +20,10 @@ class PageQualityScorerTableRules extends PageQualityScorer{
 	];
 
 
-	public function calculatePageScore( $text ) {
+	public function calculatePageScore() {
 		$response = [];
 
-		// @todo load only actual page content. right now this will also load stuff like the "protectedpagewarning" message
-		$dom = new DOMDocument('1.0', 'utf-8');
-		// Unicode-compatibility - see https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly
-		$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $text );
-
-		$tableNodes = $dom->getElementsByTagName('table');
+		$tableNodes = self::getDOM()->getElementsByTagName('table');
 	    for ($i = 0; $i < $tableNodes->length; $i++) {
 	    	$row_count = 0;
 	    	$column_count = 0;


### PR DESCRIPTION
Currently, the class to ignore is .pagequality-ignore, but this should (maybe) be configurable - maybe have "general" settings as well as per-scorer settings?