### PR TITLE
Trim the examples and the HTML surrounding them before display

### DIFF
--- a/SpecialPageQuality.php
+++ b/SpecialPageQuality.php
@@ -730,10 +730,9 @@ class SpecialPageQuality extends SpecialPage {
 				foreach( $score_responses as $response ) {
 					if ( !empty( $response[ 'example' ] ) ) {
 						$html .= '
-								 <li class="list-group-item">
-								    ' . $response[ 'example' ] . '...
-								  </li>
-						';
+								 <li class="list-group-item">' .
+						            trim( $response[ 'example' ] ) . '...' .
+								  '</li>';
 					}
 				}
 				$html .= '


### PR DESCRIPTION
This allows the editors to copy the examples and find them on page
- without it they might contain additional spaces and not be found.